### PR TITLE
auth checking for routes not in users

### DIFF
--- a/src/middlewares/auth_middleware.js
+++ b/src/middlewares/auth_middleware.js
@@ -1,0 +1,24 @@
+const { verifyToken } = require('../services/auth_services.js')
+
+const validateRequest = (request, response, next) => {
+    try {
+        if (request.headers.authorization) {
+            const token = request.headers.authorization.split(" ")[1]
+            if (!token) {
+                response.json({ error: "No token received" })
+                return
+            }
+            const decoded = verifyToken(token)
+            return next()
+        } else {
+            response.json({ error: "You are not authenticated for this page" })
+            return
+        }
+    } catch(error) {
+        response.json({error: error.message})
+    }
+}
+
+module.exports = {
+    validateRequest
+}

--- a/src/server.js
+++ b/src/server.js
@@ -86,11 +86,14 @@ app.get('/', (request, response) => {
     });
 });
 
-const groupsRouter = require('./routes/groups_routes')
-app.use("/groups", groupsRouter)
-
 const userRouter = require('./routes/user_routes.js')
 app.use('/users', userRouter)
+
+const { validateRequest } = require('./middlewares/auth_middleware.js')
+app.use(validateRequest)
+
+const groupsRouter = require('./routes/groups_routes')
+app.use("/groups", groupsRouter)
 
 const listRouter = require('./routes/list_routes.js')
 app.use('/lists', listRouter)


### PR DESCRIPTION
Authorisation checking, not allowing any access to any endpoint apart from the users routes.
When creating or logging into a user a token is returned.
Test by entering the token received into the auth header, called bearer token.